### PR TITLE
Add comment hint to SQL type declaration

### DIFF
--- a/src/HashidType.php
+++ b/src/HashidType.php
@@ -62,5 +62,10 @@ class HashidType extends IntegerType
 
         return $connection;
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }
 


### PR DESCRIPTION
Using doctrine migration or schema update will keep updating hashids field unless a comment hint is provided. This fixes the issue